### PR TITLE
update urls

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -6,9 +6,9 @@
 
   <license>BSD</license>
 
-  <url type="website">http://ros.org/wiki/rqt_runtime_monitor</url>
-  <url type="repository">https://github.com/ros-visualization/rqt_robot_plugins</url>
-  <url type="bugtracker">https://github.com/ros-visualization/rqt_robot_plugins/issues</url>
+  <url type="website">http://wiki.ros.org/rqt_runtime_monitor</url>
+  <url type="repository">https://github.com/ros-visualization/rqt_runtime_monitor</url>
+  <url type="bugtracker">https://github.com/ros-visualization/rqt_runtime_monitor/issues</url>
 
   <author>Aaron Blasdel</author>
 


### PR DESCRIPTION
With the plugin being split out from `rqt_robot_plugins` I will do a last release for Lunar (as well as re-release for Kinetic, Jade, and Indigo) in the next days. After that I will stop watching this repo, not look at issues and pull requests, and not perform new releases.

Someone needs to take over the maintenance role which specifically includes doing new releases. @ablasdel You are currently listed in the manifest as the maintainer. I am not sure if you want to take this role and fully take over this repository? Or anyone else would like to step up (@130s @mikeferguson @cottsay since you have contributed to the package in the past)?

Please let me know if you want to be added / removed from the list of maintainers in the manifest. Otherwise I will go ahead and merge this as-is and release the package a last time setting the maintenance status to `unmaintained`.