### PR TITLE
Fixes for Lyrical (setuptools and Qt6)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/rqt_runtime_monitor
+script_dir=$base/lib/rqt_runtime_monitor
 [install]
-install-scripts=$base/lib/rqt_runtime_monitor
+install_scripts=$base/lib/rqt_runtime_monitor

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
     keywords=['ROS'],
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],
@@ -34,7 +33,11 @@ setup(
         'DiagnosticsArray messages.'
     ),
     license='BSD',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'console_scripts': [
             'rqt_runtime_monitor = rqt_runtime_monitor.runtime_monitor:main'

--- a/src/rqt_runtime_monitor/runtime_monitor_widget.py
+++ b/src/rqt_runtime_monitor/runtime_monitor_widget.py
@@ -220,7 +220,7 @@ class RuntimeMonitorWidget(QWidget):
                 parent_node = self._error_node
 
             item.tree_node.setText(0, status.name + ": " + status.message)
-            item.tree_node.setData(0, Qt.UserRole, item)
+            item.tree_node.setData(0, Qt.ItemDataRole.UserRole, item)
             parent_node.addChild(item.tree_node)
 
             # expand errors automatically
@@ -228,7 +228,7 @@ class RuntimeMonitorWidget(QWidget):
             if level_int > 1 or level_int == -1:
                 parent_node.setExpanded(True)
 
-            parent_node.sortChildren(0, Qt.AscendingOrder)
+            parent_node.sortChildren(0, Qt.SortOrder.AscendingOrder)
 
             if (was_selected):
                 self.tree_widget.setCurrentItem(item.tree_node)
@@ -254,12 +254,12 @@ class RuntimeMonitorWidget(QWidget):
             parent_node = self._error_node
 
         item = TreeItem(status, QTreeWidgetItem(parent_node, [status.name + ": " + status.message]))
-        item.tree_node.setData(0, Qt.UserRole, item)
+        item.tree_node.setData(0, Qt.ItemDataRole.UserRole, item)
         parent_node.addChild(item.tree_node)
 
         self._name_to_item[status.name] = item
 
-        parent_node.sortChildren(0, Qt.AscendingOrder)
+        parent_node.sortChildren(0, Qt.SortOrder.AscendingOrder)
 
         if (select):
             item.tree_node.setSelected(True)
@@ -273,7 +273,7 @@ class RuntimeMonitorWidget(QWidget):
         return item
 
     def _fillout_info(self, node):
-        item = node.data(0, Qt.UserRole)
+        item = node.data(0, Qt.ItemDataRole.UserRole)
         if not item:
             return
 
@@ -306,10 +306,10 @@ class RuntimeMonitorWidget(QWidget):
 
     def _on_key_press(self, event):
         key = event.key()
-        if key == Qt.Key_Delete:
+        if key == Qt.Key.Key_Delete:
             nodes = self.tree_widget.selectedItems()
             if (nodes != [] and nodes[0] not in (self._ok_node, self._warning_node, self._stale_node, self._error_node)):
-                item = nodes[0].data(0, Qt.UserRole)
+                item = nodes[0].data(0, Qt.ItemDataRole.UserRole)
                 if (item.status.level == 0):
                     self._ok_node.removeChild(item.tree_node)
                 elif (item.status.level == 1):


### PR DESCRIPTION
I have tried to use the released version of rqt_runtime_monitor (deb package version `1.0.0-6resolute.20260606.035033`) on Lyrical but it was crashing because of the new scoped enums in Qt6:

```
Traceback (most recent call last):
  File "/opt/ros/lyrical/lib/python3.14/site-packages/rqt_runtime_monitor/runtime_monitor_widget.py", line 188, in _update_messages
    self._create_item(status, was_selected, True)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/ros/lyrical/lib/python3.14/site-packages/rqt_runtime_monitor/runtime_monitor_widget.py", line 257, in _create_item
    item.tree_node.setData(0, Qt.UserRole, item)
                              ^^^^^^^^^^^
AttributeError: type object 'Qt' has no attribute 'UserRole'
```

I have then applied the same fix than in this PR: https://github.com/ros-visualization/rqt_console/pull/58.

While testing locally, I have faced some setuptools deprecation warnings that I have fixed like in this PR: https://github.com/ros-visualization/rqt_msg/pull/23.

Note that this fix might break the usage on Qt5 so the current rolling branch might need to be forked for Jazzy for example.